### PR TITLE
Swap 'if' args so wildcard is after -like to allow matching

### DIFF
--- a/RemoteControlAgentSearch.ps1
+++ b/RemoteControlAgentSearch.ps1
@@ -31,7 +31,7 @@ Foreach ($process in $processes){
     Foreach($product in $products){
         $bins = $product.Executables -Split ','
         foreach($bin in $bins){
-         if($bin -like $process.Name){
+         if($process.Name -like $bin){
             $return += New-Object psobject -Property  ([ordered]@{Message="Found possible remote control application.";
                                                                   Product=$product.Software;
                                                                   ProcessName=$process.Name;


### PR DESCRIPTION
The -like operator only allows wildcards on the right side argument, so no agent names using wildcards could match (e.g. 'mesh*.exe')